### PR TITLE
Introduced LUA 5.1 support without breaking 5.2 or 5.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ Or if you want to build the latest version locally use the make script like this
 ```
 sudo ./make.sh 0.3 1
 ```
+
+Or if you want to build the latest version locally use the make like this (for Lua = 5.1):
+```
+make
+```
+
+Manual install (on Debian 8):
+```
+sudo cp liblua-leveldb.so /usr/local/lib/
+sudo mkdir /usr/local/lib/lua/5.1/
+cd /usr/local/lib/lua/5.1/
+sudo ln -s ../../liblua-leveldb.so lua-leveldb.so
+```
+
+Note - Library name collision with leveldb.so
+---------------------------------------------
+
+When LevelDB libraries are installed, there is a file with name `libleveldb.so` in `/usr/lib/`. When doing a `require 'leveldb'` in your lua-code, the loader code will find that file first. To make the loading unambiguous, it is necessary to refer this library as `liblua-leveldb.so`.
+See the below example code for `require 'lua-leveldb'`.
+
 Support
 -------
 The extension still not support the full set of operations permitted by the LevelDB library.
@@ -48,7 +68,7 @@ Basic Example
 This is a simple example about how to use the Lua extension for Google's LevelDB, just putting some data and getting it back:
 
 ```lua
-local leveldb = require 'leveldb'
+local leveldb = require 'lua-leveldb'
 
 opt = leveldb.options()
 opt.createIfMissing = true
@@ -153,7 +173,7 @@ The examples above have been adapted to be used as unit tests.
 
 Notes
 -----
-Lua-leveldb is compatible with Lua 5.2, unfortunately it is no more compatible with Lua 5.1.
+Lua-leveldb is compatible with Lua 5.1 and newer.
 
 License
 -------

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ TARGET=liblua-leveldb.so
 
 all: $(TARGET)
 
-$(TARGET):
+$(TARGET): src/lua-leveldb.cc
 	@echo -e '\033[0;34mBuilding target: $@\033[0m'
 ifneq (,$(wildcard /usr/include/leveldb/filter_policy.h))
 	$(CXX) src/lua-leveldb.cc src/lvldb-serializer.cpp $(CXXFLAGS) $(LIBFLAG) -I$(LUA_INCDIR) $(LDFLAGS) -o $(TARGET) -DLEVELDB_FILTER_POLICY_H=1

--- a/makefile
+++ b/makefile
@@ -4,24 +4,26 @@ CXXFLAGS = -Wall -fPIC
 LIBFLAG = -shared
 LDFLAGS = -lleveldb -lsnappy -lpthread
 
+LUA_VERSION=5.1
 LUA_DIR=/usr/local
-LUA_LIBDIR=$(LUA_DIR)/lib/lua/5.2
-LUA_INCDIR=/usr/include/lua5.2
-LUA_SHAREDIR=$(LUA_DIR)/share/lua/5.2
+LUA_LIBDIR=$(LUA_DIR)/lib/lua/$(LUA_VERSION)
+LUA_INCDIR=/usr/include/lua$(LUA_VERSION)
+LUA_SHAREDIR=$(LUA_DIR)/share/lua/$(LUA_VERSION)
+TARGET=liblua-leveldb.so
 
-all: leveldb.so
+all: $(TARGET)
 
-leveldb.so:
+$(TARGET):
 	@echo -e '\033[0;34mBuilding target: $@\033[0m'
 ifneq (,$(wildcard /usr/include/leveldb/filter_policy.h))
-	$(CXX) src/lua-leveldb.cc src/lvldb-serializer.cpp $(CXXFLAGS) $(LIBFLAG) -I$(LUA_INCDIR) $(LDFLAGS) -o leveldb.so -DLEVELDB_FILTER_POLICY_H=1
+	$(CXX) src/lua-leveldb.cc src/lvldb-serializer.cpp $(CXXFLAGS) $(LIBFLAG) -I$(LUA_INCDIR) $(LDFLAGS) -o $(TARGET) -DLEVELDB_FILTER_POLICY_H=1
 else
-	$(CXX) src/lua-leveldb.cc src/lvldb-serializer.cpp $(CXXFLAGS) $(LIBFLAG) -I$(LUA_INCDIR) $(LDFLAGS) -o leveldb.so
+	$(CXX) src/lua-leveldb.cc src/lvldb-serializer.cpp $(CXXFLAGS) $(LIBFLAG) -I$(LUA_INCDIR) $(LDFLAGS) -o $(TARGET)
 endif
 
 clean:
 	@echo -e '\033[0;33mCleaning binaries:\033[0m'
-	rm -f leveldb.so
+	rm -f $(TARGET)
 
 install:
 	@echo -e '\033[0;32mInstalling with luarocks\033[0m'

--- a/src/lua-leveldb.cc
+++ b/src/lua-leveldb.cc
@@ -616,6 +616,31 @@ static int lvldb_database_get(lua_State *L) {
 }
 
 /**
+ * Method that checks the given key's existence from a DB.
+ * -----------------------------------------------------$
+ * This DB related method returns in Lua:
+ *  * True if key is in DB
+ *  * False in case of error, or key not exists.
+ */
+static int lvldb_database_has(lua_State *L) {
+	DB *db = check_database(L, 1);
+
+	Slice key = lua_to_slice(L, 2);
+	string value;
+
+	Status s = db->Get(lvldb_ropt(L, 3), key, &value);
+
+	if (s.ok()) {
+		lua_pushboolean(L, true);
+	}
+	else {
+		lua_pushboolean(L, false);
+	}
+
+	return 1;
+}
+
+/**
  *
  */
 static int lvldb_database_set(lua_State *L) {
@@ -1001,6 +1026,7 @@ static const luaL_Reg lvldb_database_m[] = {
 		{ "put", lvldb_database_put },
 		{ "set", lvldb_database_set },
 		{ "get", lvldb_database_get },
+		{ "has", lvldb_database_has },
 		{ "delete", lvldb_database_del },
 		{ "iterator", lvldb_database_iterator },
 		{ "write", lvldb_database_write },

--- a/src/lua-leveldb.cc
+++ b/src/lua-leveldb.cc
@@ -173,12 +173,20 @@ static void init_complex_metatable(lua_State *L, const char *metatable_name, con
 
 	// create methods table, & add it to the table of globals
 	lua_newtable(L);
+#if LUA_VERSION_NUM > 501
 	luaL_setfuncs(L, methods, 0);
+#else
+	luaL_register(L, NULL, methods);
+#endif
 	int methods_stack = lua_gettop(L);
 
 	// create meta-table for object, & add it to the registry
 	luaL_newmetatable(L, metatable_name);
+#if LUA_VERSION_NUM > 501
 	luaL_setfuncs(L, metamethods, 0); // fill meta-table
+#else
+	luaL_register(L, NULL, metamethods);
+#endif
 	int metatable_stack = lua_gettop(L);
 
 	lua_pushliteral(L, "__metatable");
@@ -215,7 +223,11 @@ static void init_metatable(lua_State *L, const char *metatable, const struct lua
 	lua_settable(L, -3); // meta-table.__index = meta-table
 
 	// meta-table already on the stack
+#if LUA_VERSION_NUM > 501
 	luaL_setfuncs(L, lib, 0);
+#else
+	luaL_register(L, NULL, lib);
+#endif
 	lua_pop(L, 1);
 }
 
@@ -1035,7 +1047,11 @@ LUALIB_API int luaopen_leveldb(lua_State *L) {
 	lua_setfield(L, -2, "_DESCRIPTION");
 
 	// LevelDB methods
+#if LUA_VERSION_NUM > 501
 	luaL_setfuncs(L, lvldb_leveldb_m, 0);
+#else
+	luaL_register(L, NULL, lvldb_leveldb_m);
+#endif
 
 	// initialize meta-tables
 	init_metatable(L, LVLDB_MT_DB, lvldb_database_m);

--- a/src/lua-leveldb.cc
+++ b/src/lua-leveldb.cc
@@ -20,7 +20,7 @@
 #define LVLDB_MT_OPT		"leveldb.opt"
 #define LVLDB_MT_ROPT		"leveldb.ropt"
 #define LVLDB_MT_WOPT		"leveldb.wopt"
-#define LVLDB_MT_DB			"leveldb.db"
+#define LVLDB_MT_DB		"leveldb.db"
 #define LVLDB_MT_ITER		"leveldb.iter"
 #define LVLDB_MT_BATCH		"leveldb.btch"
 
@@ -299,8 +299,12 @@ static string bool_to_string(int boolean) {
  *  Check for a DB type.
  */
 static DB *check_database(lua_State *L, int index) {
-	void *ud = luaL_checkudata(L, 1, LVLDB_MT_DB);
-	luaL_argcheck(L, ud != NULL, 1, "'database' expected");
+	// UD-type: light meta @ lvldb_open()
+// LuaJIT doesn't support luaL_checkudata on light userdata
+//	void *ud = luaL_checkudata(L, index, LVLDB_MT_DB);
+	DB *ud = (DB*) lua_touserdata(L, 1);
+	luaL_argcheck(L, ud != NULL, index, "'database' expected");
+	luaL_argcheck(L, lua_islightuserdata(L, index), index, "'database' expected");
 
 	return (DB *) ud;
 }
@@ -310,11 +314,10 @@ static DB *check_database(lua_State *L, int index) {
  */
 static Options *check_options(lua_State *L, int index) {
 	Options *opt;
-	luaL_checktype(L, 1, LUA_TUSERDATA);
+	luaL_checktype(L, index, LUA_TUSERDATA);
+	// UD-type: complex metatable @ luaopen_leveldb()
 	opt = (Options*)luaL_checkudata(L, index, LVLDB_MT_OPT);
-
-	if(opt == NULL)
-		luaL_argerror(L, index, "Options is NULL");
+	luaL_argcheck(L, opt != NULL, index, "'options' expected");
 
 	return opt;
 }
@@ -323,6 +326,8 @@ static Options *check_options(lua_State *L, int index) {
  * Check for a ReadOptions type.
  */
 static ReadOptions *check_read_options(lua_State *L, int index) {
+	luaL_checktype(L, index, LUA_TUSERDATA);
+	// UD-type: complex metatable @ luaopen_leveldb()
 	void *ud = luaL_checkudata(L, index, LVLDB_MT_ROPT);
 	luaL_argcheck(L, ud != NULL, index, "'writeOptions' expected");
 
@@ -333,6 +338,8 @@ static ReadOptions *check_read_options(lua_State *L, int index) {
  * Check for a WriteOptions type.
  */
 static WriteOptions *check_write_options(lua_State *L, int index) {
+	luaL_checktype(L, index, LUA_TUSERDATA);
+	// UD-type: complex metatable @ luaopen_leveldb()
 	void *ud = luaL_checkudata(L, index, LVLDB_MT_WOPT);
 	luaL_argcheck(L, ud != NULL, index, "'readOptions' expected");
 
@@ -343,20 +350,30 @@ static WriteOptions *check_write_options(lua_State *L, int index) {
  * Check for an Iterator type.
  */
 static Iterator *check_iter(lua_State *L) {
-	void *ud = luaL_checkudata(L, 1, LVLDB_MT_ITER);
+	luaL_checktype(L, 1, LUA_TUSERDATA);
+	// UD-type: light meta @ lvldb_database_iterator()
+// LuaJIT doesn't support luaL_checkudata on light userdata
+//	void *ud = luaL_checkudata(L, 1, LVLDB_MT_ITER);
+	Iterator *ud = (Iterator*) lua_touserdata(L, 1);
 	luaL_argcheck(L, ud != NULL, 1, "'iterator' expected");
+	luaL_argcheck(L, lua_islightuserdata(L, 1), 1, "'iterator' expected");
 
-	return (Iterator *) ud;
+	return ud;
 }
 
 /**
  * Check for a WriteBatch type.
  */
 static WriteBatch *check_writebatch(lua_State *L, int index) {
-	void *ud = luaL_checkudata(L, 1, LVLDB_MT_BATCH);
-	luaL_argcheck(L, ud != NULL, 1, "'batch' expected");
+	luaL_checktype(L, index, LUA_TUSERDATA);
+	// UD-type: light meta @ lvldb_batch()
+// LuaJIT doesn't support luaL_checkudata on light userdata
+//	void *ud = luaL_checkudata(L, 1, LVLDB_MT_BATCH);
+	WriteBatch *ud = (WriteBatch*) lua_touserdata(L, 1);
+	luaL_argcheck(L, ud != NULL, index, "'batch' expected");
+	luaL_argcheck(L, lua_islightuserdata(L, index), index, "'iterator' expected");
 
-	return (WriteBatch *) ud;
+	return ud;
 }
 
 /**


### PR DESCRIPTION
By design, LUA is meant to be embedded into software. This results in situation, where there is virtually zero possibility of me upgrading LUA version. However, I'd like to add some features into my LUA, including LevelDB support. This patch adds the 5.1 build, while still working with newer versions too.